### PR TITLE
update base path for docs to edit

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -5,7 +5,10 @@ const config: DocsThemeConfig = {
   project: {
     link: "https://github.com/denepo/denepo.github.io",
   },
-  docsRepositoryBase: "https://github.com/denepo/denepo.github.io",
+  docsRepositoryBase: "https://github.com/denepo/denepo.github.io/blob/main",
+  editLink: {
+    text: 'Edit this page on GitHub'
+  },
   footer: {
     text: "You can save any page as a PDF by opening it, ctr-p, then opening the document instead of printing it.",
   },


### PR DESCRIPTION
the current path for the "edit this page" link is broken, so this commit fixes it. It also adds a more explicit title to the edit link.